### PR TITLE
Added input args to SpringApplication startup

### DIFF
--- a/src/main/java/org/openbaton/vnfm/generic/GenericVNFM.java
+++ b/src/main/java/org/openbaton/vnfm/generic/GenericVNFM.java
@@ -34,7 +34,7 @@ public class GenericVNFM extends AbstractVnfmSpringAmqp {
     private String scriptPath;
 
     public static void main(String[] args) {
-        SpringApplication.run(GenericVNFM.class);
+        SpringApplication.run(GenericVNFM.class, args);
     }
 
     @Override


### PR DESCRIPTION
Users will be able to pass parameters at program startup. Like `spring.config.location` for example.
