### PR TITLE
fix: EMS registration when original hostname changes

### DIFF
--- a/src/main/resources/user-data.sh
+++ b/src/main/resources/user-data.sh
@@ -11,7 +11,6 @@ export EMS_HEARTBEAT=
 export EMS_AUTODELETE=
 export EMS_VERSION=
 export #Hostname=
-export EMS_HOST_ID=$Hostname
 export ENDPOINT=
 
 # Hostname/IP and path of the EMS repository
@@ -109,9 +108,8 @@ configure_ems () {
     echo exchange=$EXCHANGE_NAME >> /etc/openbaton/ems/conf.ini
     echo heartbeat=$EMS_HEARTBEAT >> /etc/openbaton/ems/conf.ini
     echo autodelete=$EMS_AUTODELETE >> /etc/openbaton/ems/conf.ini
-    export hn=`hostname`
     echo type=$ENDPOINT >> /etc/openbaton/ems/conf.ini
-    echo hostname=$EMS_HOST_ID >> /etc/openbaton/ems/conf.ini
+    echo hostname=$Hostname >> /etc/openbaton/ems/conf.ini
 
     service ems restart
 }

--- a/src/main/resources/user-data.sh
+++ b/src/main/resources/user-data.sh
@@ -10,6 +10,8 @@ export EXCHANGE_NAME=
 export EMS_HEARTBEAT=
 export EMS_AUTODELETE=
 export EMS_VERSION=
+export #Hostname=
+export EMS_HOST_ID=$Hostname
 export ENDPOINT=
 
 # Hostname/IP and path of the EMS repository
@@ -109,7 +111,7 @@ configure_ems () {
     echo autodelete=$EMS_AUTODELETE >> /etc/openbaton/ems/conf.ini
     export hn=`hostname`
     echo type=$ENDPOINT >> /etc/openbaton/ems/conf.ini
-    echo hostname=$hn >> /etc/openbaton/ems/conf.ini
+    echo hostname=$EMS_HOST_ID >> /etc/openbaton/ems/conf.ini
 
     service ems restart
 }


### PR DESCRIPTION
fixes the problem in case the OS assigns a different hostname than actually given. It is not using anymore the hostname from the running instance but the hostname which is given by the orchestrator 