### PR TITLE
fix: #57 error handler of LogUtils

### DIFF
--- a/src/main/java/org/openbaton/vnfm/generic/utils/LogUtils.java
+++ b/src/main/java/org/openbaton/vnfm/generic/utils/LogUtils.java
@@ -103,9 +103,7 @@ public class LogUtils {
       log.debug("The full log path is: " + path);
       if (!f.exists()) {
         f.getParentFile().mkdirs();
-        if (!f.createNewFile()) {
-          log.error("Not able to create log file");
-        }
+	f.createNewFile();
       }
 
       if (!error) {


### PR DESCRIPTION
To solve issue #57 , i just delete log.error.
I think it's enough to know error cause by IOException and log.debug("The full log path is: " + path).