### PR TITLE
Issue 280

### DIFF
--- a/src/main/java/org/openbaton/vnfm/generic/core/LifeCycleManagement.java
+++ b/src/main/java/org/openbaton/vnfm/generic/core/LifeCycleManagement.java
@@ -65,22 +65,38 @@ public class LifeCycleManagement {
     } else {
       removingStr = "Adding ";
     }
-    for (NetworkIps networkIps : vnfcInstance.getIps()) {
-      log.debug(
-          removingStr
-              + "net: "
-              + networkIps.getNetName()
-              + " with value: "
-              + networkIps.getSubnetIps().iterator().next().getIp());
-      tempEnv.put(
-          prefix + networkIps.getNetName(), networkIps.getSubnetIps().iterator().next().getIp());
-      log.debug(
-          removingStr
-              + "net: "
-              + networkIps.getNetName()
-              + "_ips with value: "
-              + networkIps.printSubnetIps());
-      tempEnv.put(prefix + networkIps.getNetName() + "_ips", networkIps.printSubnetIps());
+    if (vnfcInstance.getFixedIps().isEmpty()) {
+      // this is the deprecated method but just in case there are instances in the database already do some minor
+      // level of support
+      for (Ip ip : vnfcInstance.getIps()) {
+        log.debug(
+            removingStr
+                + "net: "
+                + ip.getNetName()
+                + " with value: "
+                + ip.getIp());
+        tempEnv.put(
+            prefix + ip.getNetName(), ip.getIp());
+        //NOTE: this means that the list of ips is not getting populated
+      }
+    } else {
+      for (NetworkIps networkIps : vnfcInstance.getFixedIps()) {
+        log.debug(
+            removingStr
+                + "net: "
+                + networkIps.getNetName()
+                + " with value: "
+                + networkIps.getSubnetIps().iterator().next().getIp());
+        tempEnv.put(
+            prefix + networkIps.getNetName(), networkIps.getSubnetIps().iterator().next().getIp());
+        log.debug(
+            removingStr
+                + "net: "
+                + networkIps.getNetName()
+                + "_ips with value: "
+                + networkIps.printSubnetIps());
+        tempEnv.put(prefix + networkIps.getNetName() + "_ips", networkIps.printSubnetIps());
+      }
     }
     log.debug(removingStr + "floatingIp: " + vnfcInstance.getFloatingIps());
     for (Ip fip : vnfcInstance.getFloatingIps()) {


### PR DESCRIPTION
Currently if there is more than one interface (openstack port) on a single network only the first interfaces's IP address is available to the scripts as $network_name. If there is more than one subnet associated with a particular network (i.e. IPv4 and IPv6) openstack assigns IP addresses from both but the value of $network_name in the scripts is randomly assigned between the two.

Create new environmental variable called $network_name_ips that has all of the ips, subnets and interface ids.

This references issue openbaton/NFVO#280 and should be pulled with openbaton/NFVO#281